### PR TITLE
bug: id code validation has false negatives

### DIFF
--- a/api/_db.data-utils.js
+++ b/api/_db.data-utils.js
@@ -208,7 +208,7 @@ export const isIdCodeValid = (code) => {
 		return nr[10] === controlCode;
 	}
 
-	return nr[10] === (
+	const controlCode2 = (
 		nr[0]*3 +
 		nr[1]*4 +
 		nr[2]*5 +
@@ -220,4 +220,10 @@ export const isIdCodeValid = (code) => {
 		nr[8]*2 +
 		nr[9]*3
 	) % 11;
+
+	if (controlCode2 !== 10) {
+		return nr[10] === controlCode2;
+	}
+
+	return nr[10];
 };

--- a/api/_db.data-utils.js
+++ b/api/_db.data-utils.js
@@ -225,5 +225,5 @@ export const isIdCodeValid = (code) => {
 		return nr[10] === controlCode2;
 	}
 
-	return nr[10];
+	return nr[10] === 0;
 };


### PR DESCRIPTION
Id code validation fails people with an id code that passes the first check with 10 and then passes the second check with 10. Then it should just check for 0 value, but instead it looks for a 10 value.

Even though it is a simple change, I am unable to verify the fix by myself on my vercel instance.